### PR TITLE
feat(django): read-only admin for the broker tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,27 @@ connections are refreshed around each message and closed on shutdown —
 workers are long-lived threads with no request cycle to do it for them. List
 it in `MIDDLEWARE` explicitly to control its position.
 
+### Admin
+
+With `django.contrib.admin` installed, the broker tables show up in the admin
+as **Messages**, **Workers** and **Results**. Messages list the actor, args,
+retry count and the traceback of a rejected message, filterable by state and
+queue; workers are flagged `alive`/`dead` against the broker's
+`heartbeat_ttl`.
+
+Everything is read-only, including bulk actions: these tables are the
+broker's live state, and editing a row by hand corrupts the queue — clearing
+the `worker_id` of a claimed message, say, gets it delivered twice.
+
+What the admin shows is **pending work and failures, not task history**. A
+message is deleted as soon as it is acknowledged, so successfully processed
+tasks never accumulate; rejected ones stay until `purge_maxage`. Results
+appear only for actors declared with `store_results=True`.
+
+The models are unmanaged and read the configured `schema`/`prefix`, so they
+follow a customized deployment. `makemigrations` never generates anything for
+them — the tables come from this app's migration.
+
 ### Migrating from django_dramatiq
 
 1. Replace `django_dramatiq` with `dramatiq_postgres.django` in

--- a/dramatiq_postgres/django/admin.py
+++ b/dramatiq_postgres/django/admin.py
@@ -1,0 +1,126 @@
+"""Read-only admin for the broker tables.
+
+Everything here is deliberately read-only: these tables are the broker's live
+state, and editing a row by hand corrupts the queue (a claimed message whose
+``worker_id`` is cleared gets delivered twice, for instance). Use the CLI or
+the broker API to act on messages.
+"""
+
+import datetime
+
+from django.conf import settings
+from django.contrib import admin
+from django.utils import timezone
+from django.utils.html import format_html
+
+from .models import Message, Result, Worker
+
+
+class ReadOnlyAdmin(admin.ModelAdmin):
+    """Disables every write path, including the bulk-delete action."""
+
+    actions = None
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
+@admin.register(Message)
+class MessageAdmin(ReadOnlyAdmin):
+    list_display = (
+        "message_id",
+        "actor_display",
+        "queue_name",
+        "state_display",
+        "retries_display",
+        "available_at",
+        "mtime",
+    )
+    list_filter = ("state", "queue_name")
+    search_fields = ("message_id", "queue_name")
+    ordering = ("-mtime",)
+    date_hierarchy = "mtime"
+    fields = (
+        "message_id",
+        "queue_name",
+        "state",
+        "actor_display",
+        "args_display",
+        "kwargs_display",
+        "retries_display",
+        "position",
+        "available_at",
+        "mtime",
+        "worker_id",
+        "consumed_at",
+        "traceback_display",
+        "message",
+    )
+    readonly_fields = fields
+
+    @admin.display(description="actor", ordering="message__actor_name")
+    def actor_display(self, obj):
+        return obj.actor_name or "—"
+
+    @admin.display(description="state")
+    def state_display(self, obj):
+        colors = {
+            Message.QUEUED: "#1a73e8",
+            Message.CONSUMED: "#188038",
+            Message.REJECTED: "#d93025",
+        }
+        color = colors.get(obj.state, "#5f6368")
+        return format_html(
+            '<b style="color:{}">{}</b>', color, obj.state or "—"
+        )
+
+    @admin.display(description="retries")
+    def retries_display(self, obj):
+        return obj.retries if obj.retries is not None else "—"
+
+    @admin.display(description="args")
+    def args_display(self, obj):
+        return obj._payload("args") or "—"
+
+    @admin.display(description="kwargs")
+    def kwargs_display(self, obj):
+        return obj._payload("kwargs") or "—"
+
+    @admin.display(description="traceback")
+    def traceback_display(self, obj):
+        if not obj.traceback:
+            return "—"
+        return format_html(
+            '<pre style="white-space:pre-wrap;margin:0">{}</pre>',
+            obj.traceback,
+        )
+
+
+@admin.register(Worker)
+class WorkerAdmin(ReadOnlyAdmin):
+    list_display = ("worker_id", "heartbeat_at", "liveness")
+    ordering = ("-heartbeat_at",)
+
+    @admin.display(description="status")
+    def liveness(self, obj):
+        options = getattr(settings, "DRAMATIQ_BROKER", {}).get("OPTIONS", {})
+        ttl = options.get("heartbeat_ttl", 60.0)
+        deadline = timezone.now() - datetime.timedelta(seconds=ttl)
+        if obj.heartbeat_at < deadline:
+            return format_html('<b style="color:{}">dead</b>', "#d93025")
+        return format_html('<b style="color:{}">alive</b>', "#188038")
+
+
+@admin.register(Result)
+class ResultAdmin(ReadOnlyAdmin):
+    list_display = ("message_id", "expires_at")
+    search_fields = ("message_id",)
+    ordering = ("-expires_at",)
+    fields = ("message_id", "result", "expires_at")
+    readonly_fields = fields

--- a/dramatiq_postgres/django/apps.py
+++ b/dramatiq_postgres/django/apps.py
@@ -63,5 +63,28 @@ class DramatiqPostgresConfig(AppConfig):
             alias = config.get("DATABASE_ALIAS", "default")
             options["url"] = connection_kwargs(alias)
 
+        self._retarget_models(options)
+
         self.broker = PostgresBroker(**options)
         dramatiq.set_broker(self.broker)
+
+    @staticmethod
+    def _retarget_models(options):
+        """Point the introspection models at the configured schema/prefix.
+
+        Their Meta carries the stock table name, since a model's table has to
+        be known before settings are available.
+        """
+        schema = options.get("schema")
+        prefix = options.get("prefix")
+        if not schema and not prefix:
+            return
+
+        from .models import Message, Result, Worker, table_name
+
+        for model, name in (
+            (Message, "queue"),
+            (Worker, "worker"),
+            (Result, "result"),
+        ):
+            model._meta.db_table = table_name(name, schema, prefix)

--- a/dramatiq_postgres/django/models.py
+++ b/dramatiq_postgres/django/models.py
@@ -1,0 +1,110 @@
+"""Unmanaged models mapping the broker tables, for read-only introspection.
+
+These exist so the queue can be inspected from the Django admin. They are
+``managed = False``: the tables are created by the app's migration, which runs
+the same ``schema.sql`` as the CLI, and Django must never alter them.
+
+``db_table`` defaults to the stock ``"dramatiq"."<name>"``; the AppConfig
+rewrites it in ``ready()`` when ``DRAMATIQ_BROKER["OPTIONS"]`` sets a custom
+``schema`` or ``prefix``. It cannot be resolved here: Django needs the table
+name when the class is defined, which is before settings are guaranteed to be
+configured.
+"""
+
+from django.db import models
+
+__all__ = ["Message", "Worker", "Result"]
+
+
+def table_name(name, schema=None, prefix=None):
+    """Quoted "schema"."prefixname", matching what the broker builds."""
+    return f'"{schema or "dramatiq"}"."{prefix or ""}{name}"'
+
+
+class Message(models.Model):
+    """A message in the queue table.
+
+    Only pending work and failures are visible here: a message is deleted as
+    soon as it is acknowledged, so successfully processed tasks do not
+    accumulate. Rejected messages are kept until ``purge_maxage``.
+    """
+
+    QUEUED = "queued"
+    CONSUMED = "consumed"
+    REJECTED = "rejected"
+
+    message_id = models.UUIDField(primary_key=True)
+    queue_name = models.TextField()
+    state = models.TextField(null=True)
+    mtime = models.DateTimeField(null=True)
+    message = models.JSONField(null=True)
+    position = models.BigIntegerField()
+    available_at = models.DateTimeField()
+    worker_id = models.UUIDField(null=True)
+    consumed_at = models.DateTimeField(null=True)
+
+    class Meta:
+        managed = False
+        db_table = table_name("queue")
+        verbose_name = "message"
+        verbose_name_plural = "messages"
+
+    def __str__(self):
+        return f"{self.actor_name or '?'} ({self.message_id})"
+
+    def _payload(self, key, default=None):
+        if not isinstance(self.message, dict):
+            return default
+        return self.message.get(key, default)
+
+    @property
+    def actor_name(self):
+        return self._payload("actor_name")
+
+    @property
+    def retries(self):
+        return (self._payload("options") or {}).get("retries")
+
+    @property
+    def traceback(self):
+        return (self._payload("options") or {}).get("traceback")
+
+
+class Worker(models.Model):
+    """A live worker process, identified by its heartbeat.
+
+    A row whose ``heartbeat_at`` is older than the broker's ``heartbeat_ttl``
+    is a dead worker; its consumed messages are requeued by maintenance.
+    """
+
+    worker_id = models.UUIDField(primary_key=True)
+    heartbeat_at = models.DateTimeField()
+
+    class Meta:
+        managed = False
+        db_table = table_name("worker")
+        verbose_name = "worker"
+        verbose_name_plural = "workers"
+
+    def __str__(self):
+        return str(self.worker_id)
+
+
+class Result(models.Model):
+    """A stored actor result.
+
+    Only populated for actors declared with ``store_results=True``.
+    """
+
+    message_id = models.UUIDField(primary_key=True)
+    result = models.JSONField(null=True)
+    expires_at = models.DateTimeField(null=True)
+
+    class Meta:
+        managed = False
+        db_table = table_name("result")
+        verbose_name = "result"
+        verbose_name_plural = "results"
+
+    def __str__(self):
+        return str(self.message_id)

--- a/tests/func/test_django.py
+++ b/tests/func/test_django.py
@@ -20,7 +20,15 @@ def django_project():
     previous_broker = dramatiq.get_broker()
 
     settings.configure(
-        INSTALLED_APPS=["dramatiq_postgres.django"],
+        INSTALLED_APPS=[
+            # contrib.admin and its dependencies, so the app's admin module
+            # can be imported and exercised.
+            "django.contrib.contenttypes",
+            "django.contrib.auth",
+            "django.contrib.messages",
+            "django.contrib.admin",
+            "dramatiq_postgres.django",
+        ],
         DATABASES={
             "default": {
                 "ENGINE": "django.db.backends.postgresql",
@@ -111,3 +119,116 @@ def test_db_connections_middleware_closes_connections(django_project, mocker):
     mw.before_worker_thread_shutdown(None, None)
     mw.before_consumer_thread_shutdown(None, None)
     assert close_all.call_count == 3
+
+
+def test_models_map_the_broker_tables(django_project):
+    from django.core.management import call_command
+
+    from dramatiq_postgres.django.models import Message, Result, Worker
+
+    call_command("migrate", verbosity=0)
+
+    # The fixture configures a custom schema, so this also covers the
+    # retargeting done by the AppConfig.
+    assert Message._meta.db_table == '"dramatiq_django"."queue"'
+    assert Worker._meta.db_table == '"dramatiq_django"."worker"'
+    assert Result._meta.db_table == '"dramatiq_django"."result"'
+
+    # Unmanaged: the tables come from schema.sql, never from Django.
+    assert not Message._meta.managed
+
+    import dramatiq
+
+    @dramatiq.actor(queue_name="admin_q")
+    def probe():
+        pass
+
+    probe.send()
+
+    msg = Message.objects.get(queue_name="admin_q")
+    assert msg.state == Message.QUEUED
+    assert msg.actor_name == "probe"
+
+
+@pytest.fixture
+def admins(django_project):
+    from django.contrib import admin as dj_admin
+
+    from dramatiq_postgres.django.admin import (
+        MessageAdmin,
+        ResultAdmin,
+        WorkerAdmin,
+    )
+    from dramatiq_postgres.django.models import Message, Result, Worker
+
+    return [
+        MessageAdmin(Message, dj_admin.site),
+        WorkerAdmin(Worker, dj_admin.site),
+        ResultAdmin(Result, dj_admin.site),
+    ]
+
+
+def test_every_write_path_is_disabled(admins):
+    for site in admins:
+        assert not site.has_add_permission(None)
+        assert not site.has_change_permission(None)
+        assert not site.has_delete_permission(None)
+        # Without this the bulk-delete action would still write.
+        assert site.actions is None
+
+
+def test_message_fields_come_from_the_payload(django_project):
+    from django.contrib import admin as dj_admin
+
+    from dramatiq_postgres.django.admin import MessageAdmin
+    from dramatiq_postgres.django.models import Message
+
+    site = MessageAdmin(Message, dj_admin.site)
+    msg = Message(
+        queue_name="default",
+        state=Message.QUEUED,
+        message={
+            "actor_name": "send_email",
+            "args": ["someone@example.com"],
+            "kwargs": {"urgent": True},
+            "options": {"retries": 2},
+        },
+    )
+
+    assert site.actor_display(msg) == "send_email"
+    assert site.args_display(msg) == ["someone@example.com"]
+    assert site.kwargs_display(msg) == {"urgent": True}
+    assert site.retries_display(msg) == 2
+    assert "queued" in site.state_display(msg)
+
+
+def test_message_fields_tolerate_a_missing_payload(django_project):
+    from django.contrib import admin as dj_admin
+
+    from dramatiq_postgres.django.admin import MessageAdmin
+    from dramatiq_postgres.django.models import Message
+
+    site = MessageAdmin(Message, dj_admin.site)
+    msg = Message(queue_name="default", state=None, message=None)
+
+    assert site.actor_display(msg) == "—"
+    assert site.args_display(msg) == "—"
+    assert site.retries_display(msg) == "—"
+    assert site.traceback_display(msg) == "—"
+
+
+def test_worker_liveness_uses_the_heartbeat_ttl(django_project):
+    import datetime
+
+    from django.contrib import admin as dj_admin
+    from django.utils import timezone
+
+    from dramatiq_postgres.django.admin import WorkerAdmin
+    from dramatiq_postgres.django.models import Worker
+
+    site = WorkerAdmin(Worker, dj_admin.site)
+    now = timezone.now()
+
+    assert "alive" in site.liveness(Worker(heartbeat_at=now))
+    stale = now - datetime.timedelta(seconds=3600)
+    assert "dead" in site.liveness(Worker(heartbeat_at=stale))


### PR DESCRIPTION
Unmanaged models over the `queue`, `worker` and `result` tables, registered in the Django admin so a deployment can be inspected without reaching for psql.

## What it shows

- **Messages** — actor, args, kwargs, retry count, and the traceback of a rejected message. Filterable by state and queue, searchable by id, with a date hierarchy on `mtime`.
- **Workers** — flagged `alive`/`dead` against the broker's configured `heartbeat_ttl`, so a stale worker whose messages are about to be requeued is visible.
- **Results** — populated only for actors declared with `store_results=True`.

## Read-only

Everything, bulk actions included (`actions = None`). These tables are the broker's live state and editing a row by hand corrupts the queue — clearing the `worker_id` of a claimed message, for instance, gets it delivered twice.

## Design note

`db_table` carries the stock `"dramatiq"."<name>"` and the AppConfig rewrites it in `ready()` when `OPTIONS` sets a custom `schema`/`prefix`. It can't be resolved in `Meta`: that's evaluated at import time, before settings are guaranteed to be configured — the first version did exactly that and blew up with `ImproperlyConfigured` on any import outside a booted Django.

The models are `managed = False`, so `makemigrations` generates nothing for them and the tables keep coming from this app's migration running `schema.sql`. Verified against a real project with `makemigrations --check`.

## Scope caveat, documented in the README

This shows **pending work and failures, not task history**. A message is deleted as soon as it's acknowledged, so successfully processed tasks never accumulate; rejected ones stay until `purge_maxage`. Anyone arriving from `django_dramatiq` expecting its `Task` table will notice the difference.

## Tests

21 pass. The admin tests live in the func module because only one `settings.configure()` can run per process, so a second fixture configuring Django for a unit test collides with the existing one. Coverage: table mapping under a custom schema, `managed = False`, every write path disabled, payload field extraction, graceful handling of a null payload, and heartbeat liveness both sides of the TTL.

Ruff, Black and Mypy clean.